### PR TITLE
Add unit tests and pytest documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ See `erlang_examples.py` for scripted workflows demonstrating these parameters.
 - Ensure you are using a recent version of Python with `pip` available.
 - If package installation fails, verify your network connection or use a local PyPI mirror.
 - Delete the `examples` directory if you need a clean regeneration of the sample scripts and rerun `python install.py`.
+
+## Running Tests
+
+The repository includes a `tests/` directory with pytest-based unit tests. After installing the requirements you can run them with:
+
+```bash
+pytest
+```
+
+This will execute tests for the Erlang calculations and confirm that the Streamlit interface is importable.

--- a/tests/test_erlang.py
+++ b/tests/test_erlang.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+from erlang_calculator import X, CHAT, BL
+
+
+def test_erlang_b_basic():
+    assert abs(X.erlang_b(5, 10) - 0.01838457) < 1e-6
+
+
+def test_erlang_c_basic():
+    assert abs(X.erlang_c(5, 10) - 0.03610536) < 1e-6
+
+
+def test_service_level_and_asa():
+    sl = CHAT.service_level(5, 10, 180, 20)
+    asa = CHAT.asa(5, 10, 180)
+    assert abs(sl - 0.97928443) < 1e-6
+    assert abs(asa - 1.29979293) < 1e-6
+
+
+def test_required_agents():
+    agents = CHAT.required_agents(5, 180, 0.8, 20)
+    assert isinstance(agents, int)
+    assert agents >= 5
+
+
+def test_sensitivity_dataframe():
+    df = BL.sensitivity(np.linspace(4, 8, 5), agents=8, aht=180, target=20)
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["traffic", "service_level"]
+    assert len(df) == 5
+
+
+def test_monte_carlo_series():
+    series = BL.monte_carlo(6, agents=8, aht=180, target=20, iters=50)
+    assert isinstance(series, pd.Series)
+    assert len(series) == 50

--- a/tests/test_streamlit_import.py
+++ b/tests/test_streamlit_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_streamlit_app_importable():
+    module = importlib.import_module('erlang_calculator')
+    assert hasattr(module, 'run_app')


### PR DESCRIPTION
## Summary
- add pytest test suite for Erlang metrics
- check importing Streamlit app
- document how to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802280ba448327941a4d3f4df5369d