### PR TITLE
Remove unused imports

### DIFF
--- a/erlang_calculator.py
+++ b/erlang_calculator.py
@@ -9,9 +9,7 @@ import numpy as np
 import plotly.graph_objects as go
 import plotly.express as px
 from scipy import optimize
-from scipy.special import gammainc, gamma
 import math
-from typing import Union, List
 
 # =============================================================================
 # CONFIGURACIÓN DE STREAMLIT


### PR DESCRIPTION
## Summary
- clean up erlang_calculator by removing unused imports for gammainc, gamma, Union and List

## Testing
- `python3 -m py_compile erlang_calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_6881195eb1408327b4b2b677ea4101fe