### PR TITLE
Call show_methodology from main

### DIFF
--- a/erlang_calculator.py
+++ b/erlang_calculator.py
@@ -398,6 +398,9 @@ def main():
     elif module == "Staffing Optimizer":
         staffing_optimizer()
 
+    # Display methodology and formulas
+    show_methodology()
+
 def erlang_x_interface():
     st.header("📈 Erlang C/X Calculator")
     


### PR DESCRIPTION
## Summary
- show more info about formulas by calling `show_methodology()` after module interfaces

## Testing
- `python -m py_compile erlang_calculator.py`

------
https://chatgpt.com/codex/tasks/task_e_6881195fbc488327b12f9fb1140d0719